### PR TITLE
NetworkInterfaceAddress is deprecated, no longer accepts hostnames

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1054,7 +1054,7 @@ static bool check_create_domain(dds_domainid_t did, rmw_localhost_only_t localho
        comma. */
     std::string config =
       localhost_only ?
-      "<CycloneDDS><Domain><General><NetworkInterfaceAddress>localhost</NetworkInterfaceAddress>"
+      "<CycloneDDS><Domain><General><Interfaces><NetworkInterface address=\"127.0.0.1\"/></Interfaces>"
       "</General></Domain></CycloneDDS>,"
       :
       "";


### PR DESCRIPTION
Signed-off-by: Erik Boasson <eb@ilities.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/rmw_cyclonedds/1)
<!-- Reviewable:end -->
